### PR TITLE
Fixes the equirectangular image coordinate system

### DIFF
--- a/ReplicaSDK/shaders/depth-mesh-spherical.vert
+++ b/ReplicaSDK/shaders/depth-mesh-spherical.vert
@@ -56,7 +56,7 @@ void main()
     p = (MV * vec4(p, 1)).xyz;
 
     // Angles from direction vector
-    float theta = - atan(p.z, p.x);
+    float theta = - atan(d.x, d.z);
     float phi = - atan(p.y, sqrt(p.x * p.x + p.z * p.z));
 
     // Normalize to clip space

--- a/ReplicaSDK/shaders/mesh-depth-spherical.vert
+++ b/ReplicaSDK/shaders/mesh-depth-spherical.vert
@@ -45,7 +45,7 @@ void main()
     if(leftRight!=2){
       if(disc < 0){
           d=p;
-          float theta = - atan(d.z, d.x);
+          float theta = - atan(d.x, d.z);
           float phi = - atan(d.y, sqrt(d.x * d.x + d.z * d.z));
           vec4 pos;
           pos.x = (-theta / (M_PI) + 0.0) * 1;
@@ -87,7 +87,7 @@ void main()
     }
 
     // Angles from direction vector
-    float theta = - atan(d.z, d.x);
+    float theta = - atan(d.x, d.z);
     float phi = - atan(d.y, sqrt(d.x * d.x + d.z * d.z));
 
     // Normalize to clip space

--- a/ReplicaSDK/shaders/mesh-ptex-spherical.vert
+++ b/ReplicaSDK/shaders/mesh-ptex-spherical.vert
@@ -43,7 +43,7 @@ void main()
     if(leftRight!=2){
       if(disc < 0){
           d=p;
-          float theta = - atan(d.z, d.x);
+          float theta = - atan(d.x, d.z);
           float phi = - atan(d.y, sqrt(d.x * d.x + d.z * d.z));
           vec4 pos;
           pos.x = (-theta / (M_PI) + 0.0) * 1;
@@ -84,7 +84,7 @@ void main()
     }
 
     // Angles from direction vector
-    float theta = - atan(d.z, d.x);
+    float theta = - atan(d.x, d.z);
     float phi = - atan(d.y, sqrt(d.x * d.x + d.z * d.z));
 
     // Normalize to clip space

--- a/ReplicaSDK/src/depth_mesh_render.cpp
+++ b/ReplicaSDK/src/depth_mesh_render.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
   glEnable(GL_DEPTH_TEST);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  const GLenum frontFace = GL_CW;
+  const GLenum frontFace = GL_CCW;
   glFrontFace(frontFace);
   glLineWidth(1.0f);
 

--- a/ReplicaSDK/src/depth_mesh_render_batch.cpp
+++ b/ReplicaSDK/src/depth_mesh_render_batch.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
   glEnable(GL_DEPTH_TEST);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  const GLenum frontFace = GL_CW;
+  const GLenum frontFace = GL_CCW;
   glFrontFace(frontFace);
   glLineWidth(1.0f);
 

--- a/ReplicaSDK/src/depth_mesh_render_layered.cpp
+++ b/ReplicaSDK/src/depth_mesh_render_layered.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
   glEnable(GL_DEPTH_TEST);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  const GLenum frontFace = GL_CW;
+  const GLenum frontFace = GL_CCW;
   glFrontFace(frontFace);
   glLineWidth(1.0f);
 

--- a/ReplicaSDK/src/depth_mesh_render_layered_batch.cpp
+++ b/ReplicaSDK/src/depth_mesh_render_layered_batch.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[]) {
   glEnable(GL_DEPTH_TEST);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  const GLenum frontFace = GL_CW;
+  const GLenum frontFace = GL_CCW;
   glFrontFace(frontFace);
   glLineWidth(1.0f);
 

--- a/ReplicaSDK/src/depth_mesh_viewer.cpp
+++ b/ReplicaSDK/src/depth_mesh_viewer.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
   glEnable(GL_DEPTH_TEST);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  const GLenum frontFace = GL_CW;
+  const GLenum frontFace = GL_CCW;
   glFrontFace(frontFace);
   glLineWidth(1.0f);
 

--- a/ReplicaSDK/src/depth_mesh_viewer_layered.cpp
+++ b/ReplicaSDK/src/depth_mesh_viewer_layered.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
   glEnable(GL_DEPTH_TEST);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  const GLenum frontFace = GL_CW;
+  const GLenum frontFace = GL_CCW;
   glFrontFace(frontFace);
   glLineWidth(1.0f);
 

--- a/ReplicaSDK/src/render_dataset.cpp
+++ b/ReplicaSDK/src/render_dataset.cpp
@@ -90,14 +90,7 @@ int main(int argc, char* argv[]) {
   egl.PrintInformation();
 
   //Don't draw backfaces
-  GLenum frontFace = GL_CW;
-  if(spherical){
-    glFrontFace(frontFace);
-  }
-  else{
-    frontFace = GL_CCW;
-    glFrontFace(frontFace);
-  }
+  glFrontFace(GL_CCW);
 
   // Setup a framebuffer
   pangolin::GlTexture render(width, height);

--- a/ReplicaSDK/src/render_video.cpp
+++ b/ReplicaSDK/src/render_video.cpp
@@ -92,14 +92,7 @@ int main(int argc, char* argv[]) {
   egl.PrintInformation();
 
   //Don't draw backfaces
-  GLenum frontFace = GL_CW;
-  if(spherical){
-    glFrontFace(frontFace);
-  }
-  else{
-    frontFace = GL_CCW;
-    glFrontFace(frontFace);
-  }
+  glFrontFace(GL_CCW);
 
   // Setup a framebuffer
   pangolin::GlTexture render(width, height);
@@ -148,6 +141,7 @@ int main(int argc, char* argv[]) {
 
   // load mesh and textures
   PTexMesh ptexMesh(meshFile, atlasFolder, spherical);
+    printf("-----------");
   pangolin::ManagedImage<Eigen::Matrix<uint8_t, 3, 1>> image(width, height);
   pangolin::ManagedImage<Eigen::Matrix<uint8_t, 3, 1>> depthImage(width, height);
 

--- a/ReplicaSDK/src/viewer.cpp
+++ b/ReplicaSDK/src/viewer.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  const GLenum frontFace = GL_CW;
+  const GLenum frontFace = GL_CCW;
   glFrontFace(frontFace);
   glLineWidth(1.0f);
 


### PR DESCRIPTION
The branch introduces two minor fixes:
1. Make the +Z axis as forward and in the centre of the equirectangular image;
2. Flip X-axis to make the image is the same as the scene, remove the mirror of original images.

The Replica-360 (hotel_0) mesh snapshot image from Meshlab:
![image](https://user-images.githubusercontent.com/12066192/92417728-a02f6500-f15b-11ea-938a-c3cc78fa123e.png)

The original code rendered image (flip and +x as forward):
![image](https://user-images.githubusercontent.com/12066192/92417698-678f8b80-f15b-11ea-8555-16d3cb5f5d37.png)

The image render with current branch code:
![image](https://user-images.githubusercontent.com/12066192/92417713-82620000-f15b-11ea-97fd-eeef71cf5c31.png)


